### PR TITLE
Bugfix: replace jsonData option with params 

### DIFF
--- a/src/DocumentCopierBundle/Resources/public/js/startup.js
+++ b/src/DocumentCopierBundle/Resources/public/js/startup.js
@@ -106,7 +106,7 @@ pimcore.DocumentCopier = Class.create(pimcore.plugin.admin, {
             url: '/admin/api/export-document',
             method: 'POST',
 
-            jsonData: {
+            params: {
                 'path': document.path,
                 'depth': depth,
             },


### PR DESCRIPTION
Hi There,
please accept my pull request to get export button in pimcore backend working again. 
I use PImcore 6.6. where the export button does not work out of the box.
jsonData parameter is wrong because the target action method looks for path information in request and not in json..

after changing the jsonData option to params it works correct.

Kind regards,
Sonja